### PR TITLE
Add support for IV2SLS models from linearmodels package

### DIFF
--- a/examples.ipynb
+++ b/examples.ipynb
@@ -9,7 +9,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -76,7 +76,7 @@
        "<tr><td colspan=\"3\" style=\"border-bottom: 1px solid black\"></td></tr><tr><td style=\"text-align: left\">Note:</td><td colspan=\"2\" style=\"text-align: right\"><sup>*</sup>p&lt;0.1; <sup>**</sup>p&lt;0.05; <sup>***</sup>p&lt;0.01</td></tr></table>"
       ],
       "text/plain": [
-       "<stargazer.stargazer.Stargazer at 0x19581fd6dc0>"
+       "<stargazer.stargazer.Stargazer at 0x7f35ef26fdd0>"
       ]
      },
      "execution_count": 3,
@@ -180,7 +180,7 @@
        "<tr><td colspan=\"3\" style=\"border-bottom: 1px solid black\"></td></tr><tr><td style=\"text-align: left\">Note:</td><td colspan=\"2\" style=\"text-align: right\"><sup>*</sup>p&lt;0.1; <sup>**</sup>p&lt;0.05; <sup>***</sup>p&lt;0.01</td></tr></table>"
       ],
       "text/plain": [
-       "<stargazer.stargazer.Stargazer at 0x19581fd6dc0>"
+       "<stargazer.stargazer.Stargazer at 0x7f35ef26fdd0>"
       ]
      },
      "execution_count": 5,
@@ -232,7 +232,7 @@
        "<tr><td colspan=\"3\" style=\"border-bottom: 1px solid black\"></td></tr><tr><td style=\"text-align: left\">Note:</td><td colspan=\"2\" style=\"text-align: right\"><sup>*</sup>p&lt;0.1; <sup>**</sup>p&lt;0.05; <sup>***</sup>p&lt;0.01</td></tr></table>"
       ],
       "text/plain": [
-       "<stargazer.stargazer.Stargazer at 0x19581fd6dc0>"
+       "<stargazer.stargazer.Stargazer at 0x7f35ef26fdd0>"
       ]
      },
      "execution_count": 6,
@@ -277,7 +277,7 @@
        "<tr><td colspan=\"3\" style=\"border-bottom: 1px solid black\"></td></tr><tr><td style=\"text-align: left\">Note:</td><td colspan=\"2\" style=\"text-align: right\"><sup>*</sup>p&lt;0.1; <sup>**</sup>p&lt;0.05; <sup>***</sup>p&lt;0.01</td></tr></table>"
       ],
       "text/plain": [
-       "<stargazer.stargazer.Stargazer at 0x19581fd6dc0>"
+       "<stargazer.stargazer.Stargazer at 0x7f35ef26fdd0>"
       ]
      },
      "execution_count": 7,
@@ -329,7 +329,7 @@
        "<tr><td colspan=\"3\" style=\"border-bottom: 1px solid black\"></td></tr><tr><td style=\"text-align: left\">Note:</td><td colspan=\"2\" style=\"text-align: right\"><sup>*</sup>p&lt;0.1; <sup>**</sup>p&lt;0.05; <sup>***</sup>p&lt;0.01</td></tr></table>"
       ],
       "text/plain": [
-       "<stargazer.stargazer.Stargazer at 0x19581fd6dc0>"
+       "<stargazer.stargazer.Stargazer at 0x7f35ef26fdd0>"
       ]
      },
      "execution_count": 8,
@@ -381,7 +381,7 @@
        "<tr><td colspan=\"3\" style=\"border-bottom: 1px solid black\"></td></tr><tr><td style=\"text-align: left\">Note:</td><td colspan=\"2\" style=\"text-align: right\"><sup>*</sup>p&lt;0.1; <sup>**</sup>p&lt;0.05; <sup>***</sup>p&lt;0.01</td></tr></table>"
       ],
       "text/plain": [
-       "<stargazer.stargazer.Stargazer at 0x19581fd6dc0>"
+       "<stargazer.stargazer.Stargazer at 0x7f35ef26fdd0>"
       ]
      },
      "execution_count": 9,
@@ -433,7 +433,7 @@
        "<tr><td colspan=\"3\" style=\"border-bottom: 1px solid black\"></td></tr><tr><td style=\"text-align: left\">Note:</td><td colspan=\"2\" style=\"text-align: right\"><sup>*</sup>p&lt;0.1; <sup>**</sup>p&lt;0.05; <sup>***</sup>p&lt;0.01</td></tr></table>"
       ],
       "text/plain": [
-       "<stargazer.stargazer.Stargazer at 0x19581fd6dc0>"
+       "<stargazer.stargazer.Stargazer at 0x7f35ef26fdd0>"
       ]
      },
      "execution_count": 10,
@@ -479,7 +479,7 @@
        "<tr><td colspan=\"3\" style=\"border-bottom: 1px solid black\"></td></tr><tr><td style=\"text-align: left\">Note:</td><td colspan=\"2\" style=\"text-align: right\"><sup>*</sup>p&lt;0.1; <sup>**</sup>p&lt;0.05; <sup>***</sup>p&lt;0.01</td></tr></table>"
       ],
       "text/plain": [
-       "<stargazer.stargazer.Stargazer at 0x19581fd6dc0>"
+       "<stargazer.stargazer.Stargazer at 0x7f35ef26fdd0>"
       ]
      },
      "execution_count": 11,
@@ -525,7 +525,7 @@
        "<tr><td colspan=\"3\" style=\"border-bottom: 1px solid black\"></td></tr><tr><td style=\"text-align: left\">Note:</td><td colspan=\"2\" style=\"text-align: right\"><sup>*</sup>p&lt;0.1; <sup>**</sup>p&lt;0.05; <sup>***</sup>p&lt;0.01</td></tr></table>"
       ],
       "text/plain": [
-       "<stargazer.stargazer.Stargazer at 0x19581fd6dc0>"
+       "<stargazer.stargazer.Stargazer at 0x7f35ef26fdd0>"
       ]
      },
      "execution_count": 12,
@@ -571,7 +571,7 @@
        "<tr><td colspan=\"3\" style=\"border-bottom: 1px solid black\"></td></tr><tr><td style=\"text-align: left\">Note:</td><td colspan=\"2\" style=\"text-align: right\"><sup>*</sup>p&lt;0.1; <sup>**</sup>p&lt;0.05; <sup>***</sup>p&lt;0.01</td></tr></table>"
       ],
       "text/plain": [
-       "<stargazer.stargazer.Stargazer at 0x19581fd6dc0>"
+       "<stargazer.stargazer.Stargazer at 0x7f35ef26fdd0>"
       ]
      },
      "execution_count": 13,
@@ -627,7 +627,7 @@
        "<tr><td colspan=\"3\" style=\"border-bottom: 1px solid black\"></td></tr><tr><td style=\"text-align: left\">Note:</td><td colspan=\"2\" style=\"text-align: right\"><sup>*</sup>p&lt;0.1; <sup>**</sup>p&lt;0.05; <sup>***</sup>p&lt;0.01</td></tr></table>"
       ],
       "text/plain": [
-       "<stargazer.stargazer.Stargazer at 0x19581fd6dc0>"
+       "<stargazer.stargazer.Stargazer at 0x7f35ef26fdd0>"
       ]
      },
      "execution_count": 15,
@@ -677,7 +677,7 @@
        "<tr><td colspan=\"3\" style=\"border-bottom: 1px solid black\"></td></tr><tr><td style=\"text-align: left\">Note:</td><td colspan=\"2\" style=\"text-align: right\"><sup>*</sup>p&lt;0.1; <sup>**</sup>p&lt;0.05; <sup>***</sup>p&lt;0.01</td></tr></table>"
       ],
       "text/plain": [
-       "<stargazer.stargazer.Stargazer at 0x19581fd6dc0>"
+       "<stargazer.stargazer.Stargazer at 0x7f35ef26fdd0>"
       ]
      },
      "execution_count": 16,
@@ -727,7 +727,7 @@
        "<tr><td colspan=\"3\" style=\"border-bottom: 1px solid black\"></td></tr><tr><td style=\"text-align: left\">Note:</td><td colspan=\"2\" style=\"text-align: right\"><sup>*</sup>p&lt;0.1; <sup>**</sup>p&lt;0.05; <sup>***</sup>p&lt;0.01</td></tr><tr><td colspan=\"3\" style=\"text-align: right\">First note</td></tr><tr><td colspan=\"3\" style=\"text-align: right\">Second note</td></tr></table>"
       ],
       "text/plain": [
-       "<stargazer.stargazer.Stargazer at 0x19581fd6dc0>"
+       "<stargazer.stargazer.Stargazer at 0x7f35ef26fdd0>"
       ]
      },
      "execution_count": 17,
@@ -773,7 +773,7 @@
        "<tr><td style=\"text-align: left\">Largest R<sup>2</sup></td><td>Yes</td><td>Yes</td></tr><tr><td colspan=\"3\" style=\"border-bottom: 1px solid black\"></td></tr><tr><td style=\"text-align: left\">Note:</td><td colspan=\"2\" style=\"text-align: right\"><sup>*</sup>p&lt;0.1; <sup>**</sup>p&lt;0.05; <sup>***</sup>p&lt;0.01</td></tr><tr><td colspan=\"3\" style=\"text-align: right\">First note</td></tr><tr><td colspan=\"3\" style=\"text-align: right\">Second note</td></tr></table>"
       ],
       "text/plain": [
-       "<stargazer.stargazer.Stargazer at 0x19581fd6dc0>"
+       "<stargazer.stargazer.Stargazer at 0x7f35ef26fdd0>"
       ]
      },
      "execution_count": 18,
@@ -827,7 +827,7 @@
        "<tr><td style=\"text-align: left\">Largest R<sup>2</sup></td><td>Yes</td><td>Yes</td></tr><tr><td colspan=\"3\" style=\"border-bottom: 1px solid black\"></td></tr><tr><td style=\"text-align: left\">Note:</td><td colspan=\"2\" style=\"text-align: right\"><sup>*</sup>p&lt;0.1; <sup>**</sup>p&lt;0.07; <sup>***</sup>p&lt;0.05</td></tr><tr><td colspan=\"3\" style=\"text-align: right\">First note</td></tr><tr><td colspan=\"3\" style=\"text-align: right\">Second note</td></tr></table>"
       ],
       "text/plain": [
-       "<stargazer.stargazer.Stargazer at 0x19581fd6dc0>"
+       "<stargazer.stargazer.Stargazer at 0x7f35ef26fdd0>"
       ]
      },
      "execution_count": 19,
@@ -850,9 +850,7 @@
   {
    "cell_type": "code",
    "execution_count": 20,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -875,7 +873,7 @@
        "<tr><td style=\"text-align: left\">Largest R<sup>2</sup></td><td>Yes</td><td>Yes</td></tr><tr><td colspan=\"3\" style=\"border-bottom: 1px solid black\"></td></tr><tr><td style=\"text-align: left\">Note:</td></tr><td colspan=\"3\" style=\"text-align: right\">First note</td></tr><tr><td colspan=\"3\" style=\"text-align: right\">Second note</td></tr></table>"
       ],
       "text/plain": [
-       "<stargazer.stargazer.Stargazer at 0x19581fd6dc0>"
+       "<stargazer.stargazer.Stargazer at 0x7f35ef26fdd0>"
       ]
      },
      "execution_count": 20,
@@ -921,7 +919,7 @@
        "<tr><td style=\"text-align: left\">Largest R<sup>2</sup></td><td>Yes</td><td>Yes</td></tr><tr><td colspan=\"3\" style=\"border-bottom: 1px solid black\"></td></tr><tr><td style=\"text-align: left\">Note:</td></tr><td colspan=\"3\" style=\"text-align: right\">First note</td></tr><tr><td colspan=\"3\" style=\"text-align: right\">Second note</td></tr></table>"
       ],
       "text/plain": [
-       "<stargazer.stargazer.Stargazer at 0x19581fd6dc0>"
+       "<stargazer.stargazer.Stargazer at 0x7f35ef26fdd0>"
       ]
      },
      "execution_count": 21,
@@ -942,8 +940,15 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Panel"
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [
     {
@@ -975,10 +980,10 @@
        "<tr><td style=\"text-align: left\">Within R<sup>2</sup></td><td>0.168</td><td>0.177</td><td>0.109</td></tr><tr><td colspan=\"4\" style=\"border-bottom: 1px solid black\"></td></tr><tr><td style=\"text-align: left\">Note:</td><td colspan=\"3\" style=\"text-align: right\"><sup>*</sup>p&lt;0.1; <sup>**</sup>p&lt;0.05; <sup>***</sup>p&lt;0.01</td></tr></table>"
       ],
       "text/plain": [
-       "<stargazer.stargazer.Stargazer at 0x7fda5a366b10>"
+       "<stargazer.stargazer.Stargazer at 0x7f35ef287350>"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 22,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1010,11 +1015,89 @@
     "  \n",
     "panel_res"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### IV"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<table style=\"text-align:center\"><tr><td colspan=\"4\" style=\"border-bottom: 1px solid black\"></td></tr>\n",
+       "<tr><td style=\"text-align:left\"></td><tr><td></td><td colspan=\"1\">OLS</td><td colspan=\"1\">OLS</td><td colspan=\"1\">IV</td></tr><tr><td style=\"text-align:left\"></td><td>(1)</td><td>(2)</td><td>(3)</td></tr>\n",
+       "<tr><td colspan=\"4\" style=\"border-bottom: 1px solid black\"></td></tr>\n",
+       "\n",
+       "<tr><td style=\"text-align:left\">Intercept</td><td>5.861<sup>***</sup></td><td>5.861<sup>***</sup></td><td>6.771<sup>***</sup></td></tr>\n",
+       "<tr><td style=\"text-align:left\"></td><td>(0.157)</td><td>(0.157)</td><td>(0.257)</td></tr>\n",
+       "<tr><td style=\"text-align:left\">age</td><td>-0.004<sup>*</sup></td><td>-0.004<sup>*</sup></td><td>-0.013<sup>***</sup></td></tr>\n",
+       "<tr><td style=\"text-align:left\"></td><td>(0.002)</td><td>(0.002)</td><td>(0.003)</td></tr>\n",
+       "<tr><td style=\"text-align:left\">blhisp</td><td>-0.151<sup>***</sup></td><td>-0.151<sup>***</sup></td><td>-0.217<sup>***</sup></td></tr>\n",
+       "<tr><td style=\"text-align:left\"></td><td>(0.034)</td><td>(0.034)</td><td>(0.039)</td></tr>\n",
+       "<tr><td style=\"text-align:left\">female</td><td>0.058<sup>**</sup></td><td>0.058<sup>**</sup></td><td></td></tr>\n",
+       "<tr><td style=\"text-align:left\"></td><td>(0.025)</td><td>(0.025)</td><td></td></tr>\n",
+       "<tr><td style=\"text-align:left\">hi_empunion</td><td>0.074<sup>***</sup></td><td>0.074<sup>***</sup></td><td>-0.889<sup>***</sup></td></tr>\n",
+       "<tr><td style=\"text-align:left\"></td><td>(0.026)</td><td>(0.026)</td><td>(0.213)</td></tr>\n",
+       "<tr><td style=\"text-align:left\">linc</td><td>0.010<sup></sup></td><td>0.010<sup></sup></td><td>0.087<sup>***</sup></td></tr>\n",
+       "<tr><td style=\"text-align:left\"></td><td>(0.014)</td><td>(0.014)</td><td>(0.023)</td></tr>\n",
+       "<tr><td style=\"text-align:left\">totchr</td><td>0.440<sup>***</sup></td><td>0.440<sup>***</sup></td><td>0.450<sup>***</sup></td></tr>\n",
+       "<tr><td style=\"text-align:left\"></td><td>(0.009)</td><td>(0.009)</td><td>(0.010)</td></tr>\n",
+       "\n",
+       "<td colspan=\"4\" style=\"border-bottom: 1px solid black\"></td></tr>\n",
+       "<tr><td style=\"text-align: left\">Observations</td><td>10089</td><td>10089</td><td>10089</td></tr><tr><td style=\"text-align: left\">R<sup>2</sup></td><td>0.177</td><td>0.177</td><td>0.066</td></tr><tr><td style=\"text-align: left\">Residual Std. Error</td><td>0.573 (df=10082)</td><td>0.573 (df=10082)</td><td>0.350 (df=10083)</td></tr><tr><td style=\"text-align: left\">F Statistic</td><td>2262.644<sup>***</sup> (df=7; 10082)</td><td>2262.644<sup>***</sup> (df=7; 10082)</td><td>2004.325<sup>***</sup> (df=6; 10083)</td></tr>\n",
+       "<tr><td colspan=\"4\" style=\"border-bottom: 1px solid black\"></td></tr><tr><td style=\"text-align: left\">Note:</td><td colspan=\"3\" style=\"text-align: right\"><sup>*</sup>p&lt;0.1; <sup>**</sup>p&lt;0.05; <sup>***</sup>p&lt;0.01</td></tr></table>"
+      ],
+      "text/plain": [
+       "<stargazer.stargazer.Stargazer at 0x7fc48bd24150>"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import numpy as np\n",
+    "from linearmodels.datasets import meps\n",
+    "from linearmodels.iv import IV2SLS\n",
+    "\n",
+    "data = meps.load()\n",
+    "data = data.dropna()\n",
+    "\n",
+    "formula = (\n",
+    "    \"np.log(drugexp) ~ 1 + totchr + age + linc + blhisp + [hi_empunion ~ ssiratio]\"\n",
+    ")\n",
+    "mod = IV2SLS.from_formula(formula, data)\n",
+    "iv_res2 = mod.fit(cov_type=\"robust\")\n",
+    "\n",
+    "formula = \"ldrugexp ~ 1 + totchr + female + age + linc + blhisp + hi_empunion\"\n",
+    "ols = IV2SLS.from_formula(formula, data)\n",
+    "ols_res = ols.fit(cov_type=\"robust\")\n",
+    "\n",
+    "formula = \"ldrugexp ~ 1 + totchr + female + age + linc + blhisp + hi_empunion\"\n",
+    "ols_basic = ols.from_formula(formula, data).fit()\n",
+    "iv_res = Stargazer([ols_res, ols_basic, iv_res2])\n",
+    "iv_res.custom_columns(['OLS', 'OLS', 'IV'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -1028,9 +1111,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.2"
+   "version": "3.11.5"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
I have extended the support for panel models from `linearmodels` to also handle the second stage results from [IV2SLS](https://bashtage.github.io/linearmodels/iv/iv/linearmodels.iv.model.IV2SLS.html) models from `linearmodels`.
Moreover, I have included an example in the `example.ipynb` notebook.

What is left to be done is to written as `TODO:` in `linearmodels.py` inside the `translators` module.
One of those is to also handle the first stage results.